### PR TITLE
Fixed example + bug fix

### DIFF
--- a/src_py/Clothoids.i
+++ b/src_py/Clothoids.i
@@ -1,5 +1,7 @@
 %module Clothoids
 
+%include "std_string.i"
+
 %include "std_vector.i"
 %template() std::vector<double>;
 

--- a/src_py/example.py
+++ b/src_py/example.py
@@ -5,10 +5,6 @@ import matplotlib.pyplot as plt
 curve = Clothoids.ClothoidCurve("curve")
 curve.build_G1(0.0, 0.0, 0.0, 4.0, 4.0, 0.0)
 
-pydict = {"string": "Hello, World!", "number": 42}
-print(curve.get_gc())
-curve.set_gc(pydict)
-
 values = np.arange(0, curve.length(), 0.01, dtype=np.float64)
 points = np.zeros((values.size, 2))
 


### PR DESCRIPTION
I wasn't including `std_string.i` hence one couldn't pass in any name to any clothoid.